### PR TITLE
Add try/except handler for the template renderer

### DIFF
--- a/salt_tower/pillar/tower.py
+++ b/salt_tower/pillar/tower.py
@@ -253,14 +253,19 @@ class Tower(dict):
         kwargs['tower'] = context['tower']
         kwargs['minion_id'] = context['minion_id']
 
-        return salt.template.compile_template(
-            template=template,
-            renderers=self._renderers,
-            default=default,
-            blacklist=blacklist,
-            whitelist=whitelist,
-            context=context,
-            **kwargs)
+        try:
+            return salt.template.compile_template(
+                template=template,
+                renderers=self._renderers,
+                default=default,
+                blacklist=blacklist,
+                whitelist=whitelist,
+                context=context,
+                **kwargs)
+        except Exception as err:
+            log.critical("Unable to render template %s.", template)
+            log.exception(err)
+            return {}
 
 
 class Formatter(string.Formatter):


### PR DESCRIPTION
It's much nicer to get a well formatted error message telling you
in detail which file is broken instead of the whole ext_pillar
erroring out.