### PR TITLE
Dropped log level for empty (NoneType) pillar renders

### DIFF
--- a/salt_tower/pillar/tower.py
+++ b/salt_tower/pillar/tower.py
@@ -225,7 +225,7 @@ class Tower(dict):
         data = self._compile(file, context={"basedir": base})
 
         if not isinstance(data, dict):
-            LOGGER.warning("Loading %s did not return dict, but %s", file, type(data))
+            LOGGER.debug("Loading %s did not return dict, but %s", file, type(data))
             return
 
         if "include" in data:


### PR DESCRIPTION
If jinja is used to conditionally return data this is fine and expected in many cases and the log message is very chatty.
For example I have quite a few pillars that get included but have a conditional top level structure such as:

```
{%- if something %}
foo: bar
{%- endif %}
```
So in some cases nothing actually gets rendered. the log message threw me off since salt itself doesn't consider this an error so dropping the log level down to debug seems appropriate.. I think :)