### PR TITLE
Fix tower for Salt release 3003

### DIFF
--- a/salt_tower/pillar/tower.py
+++ b/salt_tower/pillar/tower.py
@@ -135,8 +135,12 @@ class Tower(dict):
 
     def _match_minion(self, tgt):
         try:
+            if hasattr(__grains__, "value"):
+                grains = __grains__.value()
+            else:
+                grains = __grains__
             return _match_minion_impl(
-                tgt, {"grains": __grains__, "pillar": self, "id": self.minion_id}
+                tgt, {"grains": grains, "pillar": dict(self), "id": self.minion_id}
             )
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.exception(err)


### PR DESCRIPTION
With the Loader changes from https://github.com/saltstack/salt/pull/59832 in
the Salt Aluminum release, this tower breaks.

The traceback is shown below:

```
[ERROR   ] can't pickle _thread.RLock objects
Traceback (most recent call last):
  File "/var/cache/salt/minion/extmods/pillar/tower.py", line 138, in _match_minion
    tgt, {"grains": grains, "pillar": self, "id": self.minion_id}
  File "/var/cache/salt/minion/extmods/pillar/tower.py", line 33, in _match_minion_impl
    dict(__opts__, **opts)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 372, in matchers
    return LazyLoader(_module_dirs(opts, "matchers"), opts, tag="matchers")
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1318, in __init__
    opts = copy.deepcopy(opts)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib64/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib64/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib64/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib64/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib64/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 169, in deepcopy
    rv = reductor(4)
TypeError: can't pickle _thread.RLock objects
```

The reason for this is that self as used for the pillar dictionary has a
LazyLoader object attached, which has an unpickable RLock object. Casting to dict()
fixes this.

Additionally the new loader code changes things in such, that grains.value() needs
to be used to get the grains instead of just a loader object. This is fixed as well.

Credits for the actual understanding of the problem on the salt side and the fix suggestion
goes to @dwoz.